### PR TITLE
Update GNOME runtime to version 47

### DIFF
--- a/com.nickgirga.webready.yml
+++ b/com.nickgirga.webready.yml
@@ -1,6 +1,6 @@
 id: com.nickgirga.webready
 runtime: org.gnome.Platform
-runtime-version: '46'
+runtime-version: '47'
 sdk: org.gnome.Sdk
 command: webready
 

--- a/com.nickgirga.webready.yml
+++ b/com.nickgirga.webready.yml
@@ -1,6 +1,6 @@
 id: com.nickgirga.webready
 runtime: org.gnome.Platform
-runtime-version: '45'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: webready
 

--- a/com.nickgirga.webready.yml
+++ b/com.nickgirga.webready.yml
@@ -35,3 +35,5 @@ modules:
       - type: git
         url: https://gitlab.com/nickgirga/webready.git
         tag: "1.0.2"
+      - type: patch
+        path: fix-desktop-issues.patch

--- a/fix-desktop-issues.patch
+++ b/fix-desktop-issues.patch
@@ -1,0 +1,39 @@
+From 15381eb5d6762af527e3bd408c157ed75053e9bc Mon Sep 17 00:00:00 2001
+From: Sabri Ünal <yakushabb@gmail.com>
+Date: Sun, 17 Nov 2024 16:57:32 +0300
+Subject: [PATCH] Fix desktop issues
+
+Remove empty tags
+Remove en_US tags
+---
+ com.nickgirga.webready.desktop | 10 ----------
+ 1 file changed, 10 deletions(-)
+
+diff --git a/com.nickgirga.webready.desktop b/com.nickgirga.webready.desktop
+index 46cf674..ffaaacd 100755
+--- a/com.nickgirga.webready.desktop
++++ b/com.nickgirga.webready.desktop
+@@ -1,20 +1,10 @@
+ [Desktop Entry]
+ Categories=Audio;AudioVideo;
+-Comment[en_US]=
+-Comment=
+ Exec=webready %f
+-GenericName[en_US]=Create web-ready animations in seconds
+ GenericName=Create web-ready animations in seconds
+ Icon=com.nickgirga.webready
+-MimeType=
+-Name[en_US]=WebReady
+ Name=WebReady
+-Path=
+ StartupNotify=true
+ Terminal=false
+-TerminalOptions=
+ Type=Application
+-X-DBUS-ServiceName=
+-X-DBUS-StartupType=
+ X-KDE-SubstituteUID=false
+-X-KDE-Username=
+--
+libgit2 1.7.2
+


### PR DESCRIPTION
- GNOME runtime version 45 has reached EOL.
- Fix desktop issues
